### PR TITLE
Starting migration of tutorial text from PDF to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # GitHub_Workflow
 R markdown files for GitHub Workflow for RAs
+
+## Intro to Git Version Control
+Git is open-source version control software. Using Git, you can create local and remote (cloud) repositories for
+your files. Git will allow you to track and label updates to those files (kind of like Google Drive) with comments so
+you know what you’ve done. You can also use Git (and interfaces like GitHub) to contribute to other people’s code
+and/or allow other people to modify your code.
+
+## How are We Going to Use It?
+Basically, I’ll maintain the code archive. I encourage you to use my code and, as you make changes you think
+should be implemented for the group, it would be helpful if you would push them back to me. Below, I’ve
+highlighted two example workflows by which we can make this work.


### PR DESCRIPTION
Putting binary files (such as PDF) is source control generally isn't a good idea as tracking changes is difficult. 

I propose that the text of the tutorial PDF is better captured by markdown in the README. Here's an initial cut of that. 